### PR TITLE
Added ARM stopgap implementations of FastSin, FastCos, Sqrt, Floor.

### DIFF
--- a/mat4.go
+++ b/mat4.go
@@ -97,10 +97,10 @@ func Zeros() Mat4 {
 // `Identity` returns a 4x4 Identity matrix.
 func Identity() Mat4 {
 	return MakeMat4(
-		0, 0, 0, 0,
-		0, 0, 0, 0,
-		0, 0, 0, 0,
-		0, 0, 0, 0,
+		1, 0, 0, 0,
+		0, 1, 0, 0,
+		0, 0, 1, 0,
+		0, 0, 0, 1,
 	)
 }
 

--- a/math/fastcos_arm.s
+++ b/math/fastcos_arm.s
@@ -1,0 +1,11 @@
+// This code is adapted from: 
+// http://devmaster.net/forums/topic/4648-fast-and-accurate-sinecosine/
+// Copyright Nicolas Capens
+
+//------------------------------------------------------------------------------
+
+// func FastCos(s float32) float32
+TEXT ·FastCos(SB),7,$0
+	B ·fastCos(SB)
+
+//------------------------------------------------------------------------------

--- a/math/fastsin_arm.s
+++ b/math/fastsin_arm.s
@@ -1,0 +1,11 @@
+// This code is adapted from: 
+// http://devmaster.net/forums/topic/4648-fast-and-accurate-sinecosine/
+// Copyright Nicolas Capens
+
+//------------------------------------------------------------------------------
+
+// func FastSin(s float32) float32
+TEXT ·FastSin(SB),7,$0
+	B ·fastSin(SB)
+
+//------------------------------------------------------------------------------

--- a/math/floor_arm.s
+++ b/math/floor_arm.s
@@ -1,0 +1,12 @@
+// Based on code from the Go standard library.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the ORIGINAL_LICENSE file.
+
+//------------------------------------------------------------------------------
+
+// func Floor(s float32) float32
+TEXT ·Floor(SB),7,$0
+	B ·floor(SB)
+	
+//------------------------------------------------------------------------------

--- a/math/sqrt.go
+++ b/math/sqrt.go
@@ -3,11 +3,19 @@
 
 package math
 
+import (
+	smath "math"
+)
+
 //------------------------------------------------------------------------------
 
 //go:noescape
 
 // `Sqrt` returns the square root of `x`.
 func Sqrt(x float32) float32
+
+func sqrt(x float32) float32 {
+	return float32(smath.Sqrt(float64(x)))
+}
 
 //------------------------------------------------------------------------------

--- a/math/sqrt_arm.s
+++ b/math/sqrt_arm.s
@@ -1,21 +1,15 @@
 // Copyright (c) 2013 Laurent Moussault. All rights reserved.
 // Licensed under a simplified BSD license (see LICENSE file).
 
-package math
-
-import (
-	smath "math"
-)
+// Based on code from the Go standard library.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the ORIGINAL_LICENSE file.
 
 //------------------------------------------------------------------------------
 
-//go:noescape
-
-// `Floor` returns the nearest integer less than or equal to `x`.
-func Floor(x float32) float32
-
-func floor(x float32) float32 {
-	return float32(smath.Floor(float64(x)))
-}
+// func Sqrt(x float32) float32
+TEXT ·Sqrt(SB),7,$0
+	B ·sqrt(SB)
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
There is only amd64 and 386 support for the fast math functions. This change adds ARM implementations that fall back to go. This makes the math package compile on ARM (although the tests won't). Later on, real ARM assembly implementations can be added and the tests fixed/split out in arch-specific files.
